### PR TITLE
Remove transaction variable used when initializing in connectors

### DIFF
--- a/src/spaceone/inventory/connector/identity_connector.py
+++ b/src/spaceone/inventory/connector/identity_connector.py
@@ -14,8 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class IdentityConnector(BaseConnector):
 
-    def __init__(self, transaction, config, **kwargs):
-        super().__init__(transaction, config, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         e = parse_grpc_endpoint(self.endpoint)
         self.client = pygrpc.client(endpoint=e['endpoint'], ssl_enabled=e['ssl_enabled'])
 

--- a/src/spaceone/inventory/connector/inventory_connector.py
+++ b/src/spaceone/inventory/connector/inventory_connector.py
@@ -15,8 +15,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class InventoryConnector(BaseConnector):
 
-    def __init__(self, transaction, config, **kwargs):
-        super().__init__(transaction, config, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         #self._check_config()
         #self._init_client()
         e = parse_grpc_endpoint(self.endpoint)

--- a/src/spaceone/inventory/connector/monitoring_connector.py
+++ b/src/spaceone/inventory/connector/monitoring_connector.py
@@ -14,8 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class MonitoringConnector(BaseConnector):
 
-    def __init__(self, transaction, config, **kwargs):
-        super().__init__(transaction, config, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         e = parse_grpc_endpoint(self.endpoint)
         _LOGGER.debug(f'endpoint: {e}')
         self.client = pygrpc.client(endpoint=e['endpoint'], ssl_enabled=e['ssl_enabled'])

--- a/src/spaceone/inventory/libs/schema/metric_schema.py
+++ b/src/spaceone/inventory/libs/schema/metric_schema.py
@@ -46,8 +46,8 @@ METRIC_SCHEMA = {
 
 
 class MetricSchemaManager(BaseManager):
-    def __init__(self, **kwargs):
-        super().__init__(transaction=None, config=None)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.providers = SUPPORTED_PROVIDERS
 
         try:


### PR DESCRIPTION
* As the transaction structure of the core framework changes, the transaction variable of the dependent microservice is removed.